### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM php:5.6.13-apache
+MAINTAINER Rizza Mendoza <mendoza.rizza@gmail.com>
+
+COPY index.php /var/www/html/index.php
+
+EXPOSE 80

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,15 @@
+#! /usr/bin/env bash
+
+# :: set a default listening port
+if [[ -z "$FOREXBOT_APP_PORT" ]]; then
+  FOREXBOT_APP_PORT=8000
+fi
+
+# :: create a docker image if it does not exist yet
+docker build -t rizzarizzarizza/forexbot .
+
+# ::  run the app
+docker run -d \
+  -p $FOREXBOT_APP_PORT:80 \
+  --name forexbot \
+  rizzarizzarizza/forexbot


### PR DESCRIPTION
This code change adds in a Dockerfile, which you can use to create a Docker image that runs the `forexbot` app in a secluded environment.

[More info on Docker here](https://www.docker.com/whatisdocker).

To deploy this app into a Docker-enabled bash environment:

```
. start.sh
```

This will automatically:
1. Create a docker image (called `rizzarizzarizza/forexbot`)
2. Run that image in a new docker container daemon, exposing port 8000 (by default).
